### PR TITLE
chore: update webpack-sane-compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ const { stop, options } = startNotifying(compiler, {/* options */});
 // Furthermore, you have access to the options that were computed by the merge of provided options and the defaults
 ```
 
-### Available options:
+### Available options
 
 | Name   | Description   | Type     | Default |
 | ------ | ------------- | -------- | ------- |

--- a/package-lock.json
+++ b/package-lock.json
@@ -6598,9 +6598,9 @@
       "dev": true
     },
     "webpack-sane-compiler-reporter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-sane-compiler-reporter/-/webpack-sane-compiler-reporter-2.0.0.tgz",
-      "integrity": "sha512-7XWW3kClDCVhJ7FlPwUunLkn2SCuXDKiLYN2ZsEHoD5JzX/05fsj+znFNZp0xFxWb3vWB5QlA1TqmScahOxapQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/webpack-sane-compiler-reporter/-/webpack-sane-compiler-reporter-3.0.2.tgz",
+      "integrity": "sha512-9vYSOEd2/qP8FqfeleMtiujnboVpH8tXS7eFDVipXvVMNwZv2TNRJzf/Dt5+IVIoNKyx4OElkdAsEX1r9jr2Fw==",
       "requires": {
         "chalk": "2.3.0",
         "figures": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     ]
   },
   "peerDependencies": {
-    "webpack-sane-compiler": "^1.0.0"
+    "webpack-sane-compiler": "^2.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^5.2.5",
@@ -63,6 +63,6 @@
     "node-notifier": "^5.1.2",
     "read-pkg-up": "^3.0.0",
     "strip-ansi": "^4.0.0",
-    "webpack-sane-compiler-reporter": "^3.0.0"
+    "webpack-sane-compiler-reporter": "^3.0.2"
   }
 }


### PR DESCRIPTION
Do not merge, dependencies need to be published.
Also need to update package-lock.